### PR TITLE
feat: full screen

### DIFF
--- a/src/components/FullScreenButton/FullScreenButton.css
+++ b/src/components/FullScreenButton/FullScreenButton.css
@@ -1,0 +1,40 @@
+.outer-container {
+      background-color: #ffffff;
+      position: relative;
+}
+
+
+
+.zoom-in-btn:hover {
+      animation: zoom-in 0.5s;
+}
+
+@keyframes zoom-in {
+
+      0%,
+      100% {
+            transform: scale(1);
+
+      }
+
+      50% {
+            transform: scale(1.5);
+      }
+}
+
+.zoom-out-btn:hover {
+      animation: zoom-out 0.5s;
+}
+
+@keyframes zoom-out {
+
+      0%,
+      100% {
+            transform: scale(-1);
+
+      }
+
+      50% {
+            transform: scale(-1.5);
+      }
+}

--- a/src/components/FullScreenButton/FullScreenButton.stories.tsx
+++ b/src/components/FullScreenButton/FullScreenButton.stories.tsx
@@ -1,0 +1,23 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import FullScreenButton from "./FullScreenButton";
+import "./FullScreenButton.css";
+
+const style: React.CSSProperties = {
+  position: "absolute",
+  right: "20px",
+  bottom: "0px",
+};
+const meta: Meta<typeof FullScreenButton> = {
+  component: FullScreenButton,
+  tags: ["autodocs"],
+};
+
+export default meta;
+
+export const Default: StoryObj<typeof FullScreenButton> = {
+  render: () => (
+    <FullScreenButton buttonStyle={style}>
+      <p>hello world</p>
+    </FullScreenButton>
+  ),
+};

--- a/src/components/FullScreenButton/FullScreenButton.tsx
+++ b/src/components/FullScreenButton/FullScreenButton.tsx
@@ -56,9 +56,19 @@ const FullScreenButton = (props: FullScreenButtonProps) => {
   return (
     <div className="outer-container" ref={resizeBtn} tabIndex={0}>
       {props.children}
-      <button style={props.buttonStyle} className={`btn`} onClick={onClick}>
+      <button
+        aria-label={
+          isFSMode
+            ? "Click on to exit full screen"
+            : "Click on to enter full screen"
+        }
+        style={props.buttonStyle}
+        className={`btn`}
+        onClick={onClick}
+      >
         {isFSMode ? (
           <svg
+            aria-hidden
             xmlns="http://www.w3.org/2000/svg"
             fill="currentColor"
             viewBox="0 0 16 16"
@@ -73,6 +83,7 @@ const FullScreenButton = (props: FullScreenButtonProps) => {
           </svg>
         ) : (
           <svg
+            aria-hidden
             className="zoom-in-btn"
             xmlns="http://www.w3.org/2000/svg"
             width="16"

--- a/src/components/FullScreenButton/FullScreenButton.tsx
+++ b/src/components/FullScreenButton/FullScreenButton.tsx
@@ -1,0 +1,94 @@
+import { useEffect, useRef, useState } from "react";
+import "../../styles/index.css";
+import "./FullScreenButton.css";
+
+type FullScreenButtonProps = {
+  children: React.ReactNode;
+  buttonStyle: React.CSSProperties;
+};
+
+/**
+ * Functionality:
+ *  - Provides a HOC that contains button
+ *  - on click it toggles between
+ *     - full screen
+ *     - normal view
+ * Api used:
+ *   - <elem>.requestFullScreen()
+ * @returns full screen button UI
+ */
+const FullScreenButton = (props: FullScreenButtonProps) => {
+  const resizeBtn = useRef<null | HTMLDivElement>(null);
+  const [isFSMode, setFSMode] = useState(false);
+
+  /**
+   * When full screen is exited , set isFSMode to false
+   */
+  const onFullScreenChange = () => {
+    if (document.fullscreenElement === null) {
+      setFSMode(false);
+    }
+  };
+
+  /**
+   * listen to the dom when it enters and exit full screen
+   * why this approach?
+   *  - certain browsers like firefox doesn't support keydown events in full screen
+   *   for security purpose
+   */
+  useEffect(() => {
+    document.addEventListener("fullscreenchange", onFullScreenChange);
+    return () => {
+      document.removeEventListener("fullscreenchange", onFullScreenChange);
+    };
+  }, []);
+
+  const onClick = () => {
+    if (!isFSMode && resizeBtn.current?.requestFullscreen) {
+      setFSMode(true);
+      resizeBtn.current.requestFullscreen();
+    } else {
+      setFSMode(false);
+      document.exitFullscreen();
+    }
+  };
+
+  return (
+    <div className="outer-container" ref={resizeBtn} tabIndex={0}>
+      {props.children}
+      <button style={props.buttonStyle} className={`btn`} onClick={onClick}>
+        {isFSMode ? (
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            fill="currentColor"
+            viewBox="0 0 16 16"
+            width="16"
+            height="16"
+            className="zoom-out-btn"
+          >
+            <path
+              fill-rule="evenodd"
+              d="M.172 15.828a.5.5 0 0 0 .707 0l4.096-4.096V14.5a.5.5 0 1 0 1 0v-3.975a.5.5 0 0 0-.5-.5H1.5a.5.5 0 0 0 0 1h2.768L.172 15.121a.5.5 0 0 0 0 .707zM15.828.172a.5.5 0 0 0-.707 0l-4.096 4.096V1.5a.5.5 0 1 0-1 0v3.975a.5.5 0 0 0 .5.5H14.5a.5.5 0 0 0 0-1h-2.768L15.828.879a.5.5 0 0 0 0-.707z"
+            />
+          </svg>
+        ) : (
+          <svg
+            className="zoom-in-btn"
+            xmlns="http://www.w3.org/2000/svg"
+            width="16"
+            height="16"
+            fill="currentColor"
+            viewBox="0 0 16 16"
+          >
+            <path
+              fillRule="evenodd"
+              d="M5.828 10.172a.5.5 0 0 0-.707 0l-4.096 4.096V11.5a.5.5 0 0 0-1 0v3.975a.5.5 0 0 0 .5.5H4.5a.5.5 0 0 0 0-1H1.732l4.096-4.096a.5.5 0 0 0 0-.707zm4.344-4.344a.5.5 0 0 0 .707 0l4.096-4.096V4.5a.5.5 0 1 0 1 0V.525a.5.5 0 0 0-.5-.5H11.5a.5.5 0 0 0 0 1h2.768l-4.096 4.096a.5.5 0 0 0 0 .707"
+            />
+          </svg>
+        )}
+      </button>
+    </div>
+  );
+};
+
+export default FullScreenButton;

--- a/src/styles/button.css
+++ b/src/styles/button.css
@@ -1,4 +1,5 @@
 .btn {
       background-color: transparent;
       border: none;
+      cursor: pointer;
 }


### PR DESCRIPTION
## ADD
 
A button with the below functionality:
  - Provides a HOC that contains a button
 - on click it toggles between
      - fullscreen
      - normal view

It also accepts children and button style as props. Depending on the use case one can decide the button style.

## Screen recording

https://github.com/shrilakshmishastry/tiny-blocks/assets/29778698/da811cac-c0e9-4aa1-bdc8-067819bc5cfc

